### PR TITLE
housekeeping: Export declarations from build dir, upgrade typed-error

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "resin-compose-parse",
   "version": "1.10.2",
   "description": "Validate, normalise and parse docker-compose files into usable and fully typed objects",
-  "main": "src/index",
-  "types": "src/index.ts",
+  "main": "build/index.js",
+  "types": "build/index.d.ts",
   "scripts": {
     "clean": "rimraf '{src,test,typings}/**/*.{js,js.map}'",
     "lint": "tslint '{src,test,typings}/**/*.ts'",
@@ -27,7 +27,7 @@
     "@types/node": "^8.0.55",
     "ajv": "^6.0.1",
     "lodash": "^4.17.4",
-    "typed-error": "^2.0.0"
+    "typed-error": "^3.0.0"
   },
   "devDependencies": {
     "@types/chai": "^4.0.8",

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,4 +1,4 @@
-import TypedError = require('typed-error');
+import { TypedError } from 'typed-error';
 
 export class ValidationError extends TypedError {}
 export class InternalInconsistencyError extends TypedError {}

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs';
 
 import * as ajv from 'ajv';
-import TypedError = require('typed-error');
+import { TypedError } from 'typed-error';
 
 export class SchemaError extends TypedError {}
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -14,12 +14,12 @@ export type ListOfUniqueItems<T> = T[];
 export type ListOrDict = ListOfUniqueItems<string> | Dict<Value>;
 export type StringOrList = string | ListOfUniqueItems<string>;
 
-interface BlkioLimit {
+export interface BlkioLimit {
 	path?: string;
 	rate?: number | ByteValue;
 }
 
-interface BlkioWeight {
+export interface BlkioWeight {
 	path?: string;
 	weight?: number;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,13 @@
 {
   "compilerOptions": {
     "module": "commonjs",
+    "outDir": "./build",
+    "target": "es6",
     "noImplicitAny": true,
     "noUnusedParameters": true,
     "noUnusedLocals": true,
     "preserveConstEnums": true,
+    "declaration": true,
     "removeComments": true,
     "sourceMap": true,
     "strictNullChecks": true


### PR DESCRIPTION
Exporting the types as a `.ts` file is causing all sorts of problems downstream. I've changed the module to build declaration files and export those instead.

I also upgraded typed-error, which suffered from the same problem in v2, and has went through the same change in v3.

Also bump to es6 which is now required for typed-error.

Change-type: major
Signed-off-by: Cameron Diver <cameron@resin.io>