### PR TITLE
Ensure we can handle `null` networks and volumes

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -181,8 +181,8 @@ export interface Volume {
 export interface Composition {
 	version: string;
 	services: Dict<Service>;
-	networks?: Dict<Network | null>;
-	volumes?: Dict<Volume | null>;
+	networks?: Dict<Network>;
+	volumes?: Dict<Volume>;
 }
 
 export interface BuildConfig {

--- a/test/all.spec.ts
+++ b/test/all.spec.ts
@@ -94,6 +94,22 @@ describe('normalization', () => {
 		expect(c.services.s3.ports).to.deep.equal([ '1000', '1001:1002', '1003:1004/tcp' ]);
 		done();
 	});
+
+	it('networks', (done) => {
+		expect(c.networks).to.deep.equal({
+			n1: {},
+			n2: {},
+		});
+		done();
+	});
+
+	it('volumes', (done) => {
+		expect(c.volumes).to.deep.equal({
+			v1: {},
+			v2: {},
+		});
+		done();
+	});
 });
 
 describe('validation', () => {

--- a/test/fixtures/default.json
+++ b/test/fixtures/default.json
@@ -1,5 +1,13 @@
 {
   "version": "2",
+  "networks": {
+    "n1": {},
+    "n2": null
+  },
+  "volumes": {
+    "v1": {},
+    "v2": null
+  },
   "services": {
     "s1": {
       "build": "./s1",


### PR DESCRIPTION
The schema specifies that top-level `networks` and `volumes` must be
maps of strings to proper objects. `docker-compose` allows `null`s as
values and transforms them automatically to empty objects before validating
the composition.

This aligns our behaviour with docker-compose.

Change-type: patch
Signed-off-by: Akis Kesoglou <akis@resin.io>