### PR TITLE
compose: Add "tty: true" to the default composition

### DIFF
--- a/src/compose.ts
+++ b/src/compose.ts
@@ -25,6 +25,7 @@ services:
   main:
     ${context}
     privileged: true
+    tty: true
     restart: always
     network_mode: host
     volumes:


### PR DESCRIPTION
This fixes issues on supervisors > 7.20.0 with single-container apps
and systemd enabled.

Change-type: patch
Signed-off-by: Pablo Carranza Velez <pablocarranza@gmail.com>